### PR TITLE
Add option to specify custom job template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ For all instances of each desired Role, circlecigen will generate a deployment p
 * an approval step, followed by
 * a post-approve job for each instance
 
-#### Setup example for a terraform EKS pipeline
+Optionally, a custom template of a CircleCI workflow job can be defined and circlecigen will generate a deployment pipeline with jobs for all the instances running in parallel.
+
+### Setup Examples
+#### 1. Setup example for a terraform EKS pipeline
 
 Let's stay with the EKS example mentioned above. Assume that Production requires six (6) clusters in six different regions, Nonproduction likewise requires cluster in each of the same six regions, and an additional three clusters spanning nearby global localities are required to support the software-defined lifecycle of this infrastructure. Therefore we have three environment Roles: infra-dev role that is deployed on git-push, and the nonprod and prod roles that release consequtively upon git-tag.  
 
@@ -641,4 +644,103 @@ workflows:
           name: apply nonprod-ap-southwest-1 change plan
           ...
           filters: *on-tag-main
+```
+
+#### 2. Setup example for a job to run nightly integration tests
+
+In this example we start by setting up the `environments/multi.json` and `environments/default.json` as from before. We also set up any relevant role-specific overrides, and the CircleCI config file (`.circleci/config.yml`) as from before.
+
+We then create a custom template file which will be specified with the `--template` flag. Let's use the example below:
+```yaml
+      - integration-tests:
+          name: {{env_instance}} integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: {{env_instance}}
+          workspace: {{env_instance}}
+          filters: {{filters}}
+```
+
+The resulting pipeline from using the above custom template would then look like the following:
+```yaml
+---
+version: 2.1
+
+orbs:
+  continuation: circleci/continuation@0.3.1
+
+on-push-main: &on-push-main
+  branches:
+    only: /main/
+  tags:
+    ignore: /.*/
+
+commands:
+
+  setup-commands:
+    parameters:
+      ...
+    steps:
+      ...
+
+  static-code-test-commands:
+    parameters:
+      ...
+    steps:
+      ...
+
+  before-instance-specific-parallel-job-commands:
+    parameters:
+      ...
+    steps:
+      ...
+
+  after-instance-specific-parallel-job-commands:
+    parameters:
+      ...
+    steps:
+      ...
+
+
+workflows:
+  version: 2
+
+  release-pipeline:
+    jobs:
+      - integration-tests:
+          name: nonprod-us-west-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: nonprod-us-west-2
+          workspace: nonprod-us-west-2
+          filters: *on-push-main
+
+      - integration-tests:
+          name: nonprod-us-east-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: nonprod-us-east-2
+          workspace: nonprod-us-east-2
+          filters: *on-push-main
+
+      - integration-tests:
+          name: prod-us-west-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: prod-us-west-2
+          workspace: prod-us-west-2
+          filters: *on-push-main
+
+      - integration-tests:
+          name: prod-us-east-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: prod-us-east-2
+          workspace: prod-us-east-2
+          filters: *on-push-main
 ```

--- a/README.md
+++ b/README.md
@@ -457,6 +457,22 @@ commands:
     steps:
       ...
 
+jobs:
+
+  my-pre-deploy-jobs:
+    parameters:
+      ...
+    docker:
+      - image: ...
+    steps:
+      - setup-commands:
+          parameters: << parameters... >>
+      - static-code-test-commands:
+          parameters: << parameters... >>
+
+  launch-dynamic-pipeline:
+    parameters:
+      ...
 
 workflows:
   version: 2
@@ -702,6 +718,22 @@ commands:
     steps:
       ...
 
+jobs:
+
+  my-pre-deploy-jobs:
+    parameters:
+      ...
+    docker:
+      - image: ...
+    steps:
+      - setup-commands:
+          parameters: << parameters... >>
+      - static-code-test-commands:
+          parameters: << parameters... >>
+
+  launch-dynamic-pipeline:
+    parameters:
+      ...
 
 workflows:
   version: 2

--- a/env_test/custom.yml
+++ b/env_test/custom.yml
@@ -1,0 +1,10 @@
+      - integration-tests:
+          name: {{env_instance}} integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: {{env_instance}}
+          workspace: {{env_instance}}
+          filters: {{filters}}
+
+

--- a/env_test/generated_config.yml
+++ b/env_test/generated_config.yml
@@ -56,6 +56,26 @@ commands:
           command: bash scripts/write_cluster_credentials.sh << parameters.region >>
 
 
+jobs:
+
+  launch-dynamic-pipeline:
+    parameters:
+      workflow-name:
+        description: Custom name for the resulting workflow within the generated_config.yml
+        type: string
+      multi-config:
+        description: name of the multi-environment definition/configuration file to use
+        type: string
+        default: multi.json
+    executor: continuation/default
+    steps:
+      - checkout
+      - run:
+          name: generate continuation pipeline
+          command: circlecigen --workflow << parameters.workflow-name >>
+      - continuation/continue:
+          configuration_path: .circleci/generated_config.yml
+
 
 workflows:
   version: 2

--- a/env_test/template_generated_config.yml
+++ b/env_test/template_generated_config.yml
@@ -1,0 +1,100 @@
+---
+version: 2.1
+
+
+orbs:
+  terraform: twdps/terraform@0.6.0
+
+# =================== global config
+
+globals:
+ - &context di-DR-lab
+
+on-push-main: &on-push-main
+  branches:
+    only: /main/
+  tags:
+    ignore: /.*/
+
+# ===================================
+
+commands:
+
+  set-environment:
+    description: generate environment credentials and configuration from templates
+    parameters:
+      cluster:
+        description: cluster name to use for configuration
+        type: string
+      source-env:
+        description: .env file to source into BASH_ENV
+        type: string
+    steps:
+      - op/env:
+          env-file: << parameters.source-env >>
+      - run:
+          name: set ~/.terraformrc
+          command: op inject -i tpl/terraformrc.tpl -o ~/.terraformrc
+      - run:
+          name: set << parameters.cluster >> environment variables
+          command: |
+            op inject -i environments/<< parameters.cluster >>.auto.tfvars.json.tpl -o << parameters.cluster >>.auto.tfvars.json
+
+  store-system-credentials:
+    parameters:
+      region:
+        type: string
+    steps:
+      - run:
+          name: install teller
+          command: |
+            wget https://github.com/tellerops/teller/releases/download/v1.5.6/teller_1.5.6_Linux_x86_64.tar.gz
+            sudo tar -xvf teller_1.5.6_Linux_x86_64.tar.gz
+            sudo mv teller /usr/local/bin/.
+      - run:
+          name: write cluster kubeconfig to secrets store
+          command: bash scripts/write_cluster_credentials.sh << parameters.region >>
+
+
+
+workflows:
+  version: 2
+
+  continuation-generated-workflow:
+    jobs:
+      - integration-tests:
+          name: nonprod-us-west-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: nonprod-us-west-2
+          workspace: nonprod-us-west-2
+          filters: *on-tag-main
+
+      - integration-tests:
+          name: nonprod-us-east-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: nonprod-us-east-2
+          workspace: nonprod-us-east-2
+          filters: *on-tag-main
+
+      - integration-tests:
+          name: prod-us-west-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: prod-us-west-2
+          workspace: prod-us-west-2
+          filters: *on-tag-main
+
+      - integration-tests:
+          name: prod-us-east-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: prod-us-east-2
+          workspace: prod-us-east-2
+          filters: *on-tag-main
+

--- a/env_test/template_generated_config.yml
+++ b/env_test/template_generated_config.yml
@@ -56,6 +56,26 @@ commands:
           command: bash scripts/write_cluster_credentials.sh << parameters.region >>
 
 
+jobs:
+
+  launch-dynamic-pipeline:
+    parameters:
+      workflow-name:
+        description: Custom name for the resulting workflow within the generated_config.yml
+        type: string
+      multi-config:
+        description: name of the multi-environment definition/configuration file to use
+        type: string
+        default: multi.json
+    executor: continuation/default
+    steps:
+      - checkout
+      - run:
+          name: generate continuation pipeline
+          command: circlecigen --workflow << parameters.workflow-name >>
+      - continuation/continue:
+          configuration_path: .circleci/generated_config.yml
+
 
 workflows:
   version: 2

--- a/src/circlecigen.py
+++ b/src/circlecigen.py
@@ -64,7 +64,7 @@ def cli(pipeline, outfile, envpath, multifile, defaultparams, tfvars, workflow, 
     """
     validate_filepath(envpath, "envpath")
     validate_filepath(pipepath, "pipepath")
-    validate_filepath(template, "template")
+    validate_filepath(f"{pipepath}/{template}", "template")
 
     if tfvars:
         result = generate_environment_tfvar_files(pipeline, envpath,
@@ -73,9 +73,11 @@ def cli(pipeline, outfile, envpath, multifile, defaultparams, tfvars, workflow, 
         click.echo(f"{result} tfvars created in {envpath}/")
     else:
         click.echo("Not generating tfvars.json files")
-    generate_config(pipeline, 
+    generate_config(pipeline,
                     pipepath,
                     outfile,
                     envpath,
                     read_json_file(envpath, multifile),
-                    workflow)
+                    workflow,
+                    template
+                    )

--- a/src/circlecigen.py
+++ b/src/circlecigen.py
@@ -18,7 +18,7 @@ from src.template import generate_config
     callback=validate_filepath_arg)
 @click.option("--template", default=None,
     help="""Custom CircleCI template file to use for generating jobs. This is optional.
-            If not provided .circleci/pre_approve.yml and .circleci/post_approve.yml will be used""",
+            If not provided, pre_approve.yml and post_approve.yml in the pipepath directory will be used""",
     callback=validate_filepath_arg)
 @click.option("--defaultparams", default="default.json",
     help="Default parameters file. Default is default.tfvars.json",

--- a/src/circlecigen.py
+++ b/src/circlecigen.py
@@ -16,6 +16,10 @@ from src.template import generate_config
 @click.option("--multifile", default="multi.json",
     help="Multi-environment config file. Default is multi.json",
     callback=validate_filepath_arg)
+@click.option("--template", default=None,
+    help="""Custom CircleCI template file to use for generating jobs. This is optional.
+            If not provided .circleci/pre_approve.yml and .circleci/post_approve.yml will be used""",
+    callback=validate_filepath_arg)
 @click.option("--defaultparams", default="default.json",
     help="Default parameters file. Default is default.tfvars.json",
     callback=validate_filepath_arg)
@@ -28,13 +32,14 @@ from src.template import generate_config
     help="Override default config.yml location for testing",
     callback=validate_filepath_arg)
 @click.argument('pipeline', nargs=1)
-def cli(pipeline, outfile, envpath, multifile, defaultparams, tfvars, workflow, pipepath):
+def cli(pipeline, outfile, envpath, multifile, defaultparams, tfvars, workflow, pipepath, template):
     """
 
     Inputs 
 
       .circleci/pre_approve.yml
       .circleci/post_approve.yml
+      .circleci/custom_template.yml (optional)
 
       environments/
 
@@ -59,6 +64,7 @@ def cli(pipeline, outfile, envpath, multifile, defaultparams, tfvars, workflow, 
     """
     validate_filepath(envpath, "envpath")
     validate_filepath(pipepath, "pipepath")
+    validate_filepath(template, "template")
 
     if tfvars:
         result = generate_environment_tfvar_files(pipeline, envpath,

--- a/src/template.py
+++ b/src/template.py
@@ -151,10 +151,10 @@ def generate_config_lines(pipepath):
 
 
 def _read_until_jobs_or_workflows(f):
-    """Generator that reads lines from file object f until it encounters a line starting with 'jobs:' or 'workflows:'"""
+    """Generator that reads lines from file object f until it encounters a line starting with 'workflows:'"""
     for line in f:
         # initially, 
-        if line.startswith("jobs:") or line.startswith("workflows:"):
+        if line.startswith("workflows:"):
             break
         yield line
 

--- a/src/template.py
+++ b/src/template.py
@@ -23,7 +23,7 @@ PRIOR_APPROVAL="""
             - approve {} changes
 """
 
-def generate_config(use_pipeline, pipepath, outfile, envpath, environs, workflow):
+def generate_config(use_pipeline, pipepath, outfile, envpath, environs, workflow, template):
     """create generated_config.yaml for continuation orb"""
 
     # use the specified filter to generate a pipeline only for the desired trigger
@@ -37,7 +37,7 @@ def generate_config(use_pipeline, pipepath, outfile, envpath, environs, workflow
 
     # setup the jinja templates
     je = Environment(loader=FileSystemLoader(f"{pipepath}/"), autoescape=True)
-    pre, approve, post = get_templates(je, pipepath)
+    pre, approve, post, custom = get_templates(je, pipepath, template)
 
     # setup Dict for the approval job template 
     approve_vars = {}
@@ -56,17 +56,21 @@ def generate_config(use_pipeline, pipepath, outfile, envpath, environs, workflow
             if role == "filter":
                 continue
 
-            # when the approval template is generate, it must be populated with
-            # a list of all instances for which a pre-approval template is
-            # generated. That is returned by this job.
-            approvalrequiredjobs = generate_pre_approval_jobs(f, envpath, pre, pipeline, role, priorapprovalrequired)
+            if custom:
+                generate_custom_jobs(f, envpath, custom, pipeline, role)
+                continue
+            else:
+                # when the approval template is generated, it must be populated with
+                # a list of all instances for which a pre-approval template will be
+                # generated. That is returned by this job.
+                approvalrequiredjobs = generate_pre_approval_jobs(f, envpath, pre, pipeline, role, priorapprovalrequired)
 
-            # generate approval job for the current role, a human will trigger the post- phase
-            generate_approval_jobs(f, approve, approve_vars, approvalrequiredjobs, role)
-            generate_post_approval_jobs(f, envpath, post, pipeline, role)
+                # generate approval job for the current role, a human will trigger the post- phase
+                generate_approval_jobs(f, approve, approve_vars, approvalrequiredjobs, role)
+                generate_post_approval_jobs(f, envpath, post, pipeline, role)
 
-            # record the current role, to provide 'requires:' list in any subsequent pre- jobs
-            priorapprovalrequired = role
+                # record the current role, to provide 'requires:' list in any subsequent pre- jobs
+                priorapprovalrequired = role
 
 def generate_pre_approval_jobs(f, envpath, pre, pipeline, role, priorapprovalrequired):
     # generate a pre-approval job for each instance in the role,
@@ -114,12 +118,28 @@ def generate_post_approval_jobs(f, envpath, post, pipeline, role):
             })
             f.write(post.render(instance_vars))
 
-def get_templates(je, pipepath):
+
+def generate_custom_jobs(f, envpath, custom, pipeline, role):
+    # generate a custom job for each instance in the role,
+    # if a custom template file (specified by the --template flag) exists
+    for instance in pipeline[role]:
+        instance_vars=read_json_file(envpath, f"{instance}.tfvars.json")
+        instance_vars.update({
+            "filters": pipeline["filter"],
+            "role": role,
+            "envpath": envpath
+        })
+        f.write(custom.render(instance_vars))
+
+
+def get_templates(je, pipepath, template=None):
     """setup the jinja templates"""
     pre = je.get_template("pre-approve.yml") if isfile(f"{pipepath}/pre-approve.yml") else 0
     post = je.get_template("post-approve.yml") if isfile(f"{pipepath}/post-approve.yml") else 0
+    custom = je.get_template(f"{template}") if isfile(f"{pipepath}/{template}") else 0
     approve = je.from_string(APPROVE_TEMPLATE)
-    return pre, approve, post
+    return pre, approve, post, custom
+
 
 def generate_config_lines(pipepath):
     """Read config.yml and yield lines that don't start with 'setup:' until it encounters a line starting with 'jobs:' or 'workflows:'"""

--- a/test/generated_config.yml
+++ b/test/generated_config.yml
@@ -56,6 +56,26 @@ commands:
           command: bash scripts/write_cluster_credentials.sh << parameters.region >>
 
 
+jobs:
+
+  launch-dynamic-pipeline:
+    parameters:
+      workflow-name:
+        description: Custom name for the resulting workflow within the generated_config.yml
+        type: string
+      multi-config:
+        description: name of the multi-environment definition/configuration file to use
+        type: string
+        default: multi.json
+    executor: continuation/default
+    steps:
+      - checkout
+      - run:
+          name: generate continuation pipeline
+          command: circlecigen --workflow << parameters.workflow-name >>
+      - continuation/continue:
+          configuration_path: .circleci/generated_config.yml
+
 
 workflows:
   version: 2

--- a/test/generated_config_setup.yml
+++ b/test/generated_config_setup.yml
@@ -56,6 +56,26 @@ commands:
           command: bash scripts/write_cluster_credentials.sh << parameters.region >>
 
 
+jobs:
+
+  launch-dynamic-pipeline:
+    parameters:
+      workflow-name:
+        description: Custom name for the resulting workflow within the generated_config.yml
+        type: string
+      multi-config:
+        description: name of the multi-environment definition/configuration file to use
+        type: string
+        default: multi.json
+    executor: continuation/default
+    steps:
+      - checkout
+      - run:
+          name: generate continuation pipeline
+          command: circlecigen --workflow << parameters.workflow-name >>
+      - continuation/continue:
+          configuration_path: .circleci/generated_config.yml
+
 
 workflows:
   version: 2

--- a/test/template_generated_config.yml
+++ b/test/template_generated_config.yml
@@ -1,0 +1,100 @@
+---
+version: 2.1
+
+
+orbs:
+  terraform: twdps/terraform@0.6.0
+
+# =================== global config
+
+globals:
+ - &context di-DR-lab
+
+on-push-main: &on-push-main
+  branches:
+    only: /main/
+  tags:
+    ignore: /.*/
+
+# ===================================
+
+commands:
+
+  set-environment:
+    description: generate environment credentials and configuration from templates
+    parameters:
+      cluster:
+        description: cluster name to use for configuration
+        type: string
+      source-env:
+        description: .env file to source into BASH_ENV
+        type: string
+    steps:
+      - op/env:
+          env-file: << parameters.source-env >>
+      - run:
+          name: set ~/.terraformrc
+          command: op inject -i tpl/terraformrc.tpl -o ~/.terraformrc
+      - run:
+          name: set << parameters.cluster >> environment variables
+          command: |
+            op inject -i environments/<< parameters.cluster >>.auto.tfvars.json.tpl -o << parameters.cluster >>.auto.tfvars.json
+
+  store-system-credentials:
+    parameters:
+      region:
+        type: string
+    steps:
+      - run:
+          name: install teller
+          command: |
+            wget https://github.com/tellerops/teller/releases/download/v1.5.6/teller_1.5.6_Linux_x86_64.tar.gz
+            sudo tar -xvf teller_1.5.6_Linux_x86_64.tar.gz
+            sudo mv teller /usr/local/bin/.
+      - run:
+          name: write cluster kubeconfig to secrets store
+          command: bash scripts/write_cluster_credentials.sh << parameters.region >>
+
+
+
+workflows:
+  version: 2
+
+  continuation-generated-workflow:
+    jobs:
+      - integration-tests:
+          name: nonprod-us-west-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: nonprod-us-west-2
+          workspace: nonprod-us-west-2
+          filters: *on-tag-main
+
+      - integration-tests:
+          name: nonprod-us-east-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: nonprod-us-east-2
+          workspace: nonprod-us-east-2
+          filters: *on-tag-main
+
+      - integration-tests:
+          name: prod-us-west-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: prod-us-west-2
+          workspace: prod-us-west-2
+          filters: *on-tag-main
+
+      - integration-tests:
+          name: prod-us-east-2 integration test
+          context: << pipeline.parameters.context >>
+          shell: << pipeline.parameters.shell-options >>
+          executor-image: << pipeline.parameters.executor-image >>
+          instance_name: prod-us-east-2
+          workspace: prod-us-east-2
+          filters: *on-tag-main
+

--- a/test/template_generated_config.yml
+++ b/test/template_generated_config.yml
@@ -56,6 +56,26 @@ commands:
           command: bash scripts/write_cluster_credentials.sh << parameters.region >>
 
 
+jobs:
+
+  launch-dynamic-pipeline:
+    parameters:
+      workflow-name:
+        description: Custom name for the resulting workflow within the generated_config.yml
+        type: string
+      multi-config:
+        description: name of the multi-environment definition/configuration file to use
+        type: string
+        default: multi.json
+    executor: continuation/default
+    steps:
+      - checkout
+      - run:
+          name: generate continuation pipeline
+          command: circlecigen --workflow << parameters.workflow-name >>
+      - continuation/continue:
+          configuration_path: .circleci/generated_config.yml
+
 
 workflows:
   version: 2

--- a/test/test_circlecigen.py
+++ b/test/test_circlecigen.py
@@ -43,6 +43,12 @@ def test_circlecigen_with_invalid_pipepath_name():
   assert result.exit_code == 2
   assert "Invalid value for '--pipepath'" in result.output
 
+def test_circlecigen_with_invalid_template_name():
+  runner = CliRunner()
+  result = runner.invoke(cli, ['sandbox', '--template', 'invalid:template'])
+  assert result.exit_code == 2
+  assert "Invalid value for '--template'" in result.output
+
 def test_circlecigen_help():
   runner = CliRunner()
   result = runner.invoke(cli, ["--help"])
@@ -55,5 +61,5 @@ def test_circlecigen_with_missing_pipeline_argument():
 
 def test_circlecigen_with_test_env_values():
   runner = CliRunner()
-  result = runner.invoke(cli, ["release", "--envpath", "env_test", "--pipepath", "env_test", "--template", "env_test"])
+  result = runner.invoke(cli, ["release", "--envpath", "env_test", "--pipepath", "env_test", "--template", "custom.yml"])
   assert "4 tfvars created in env_test/" in result.output

--- a/test/test_circlecigen.py
+++ b/test/test_circlecigen.py
@@ -55,5 +55,5 @@ def test_circlecigen_with_missing_pipeline_argument():
 
 def test_circlecigen_with_test_env_values():
   runner = CliRunner()
-  result = runner.invoke(cli, ["release", "--envpath", "env_test", "--pipepath", "env_test"])
+  result = runner.invoke(cli, ["release", "--envpath", "env_test", "--pipepath", "env_test", "--template", "env_test"])
   assert "4 tfvars created in env_test/" in result.output

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -54,11 +54,25 @@ def test_get_templates():
     envpath = "env_test"
     je = Environment(loader=FileSystemLoader(f"{envpath}/"))
 
-    pre, approve, post = get_templates(je, envpath)
+    pre, approve, post, custom = get_templates(je, envpath)
     
     assert isinstance(pre, Template)
     assert isinstance(post, Template)
     assert isinstance(approve, Template)
+
+
+def test_get_custom_template():
+    envpath = "env_test"
+    custom_template = "custom.yml"
+    je = Environment(loader=FileSystemLoader(f"{envpath}/"))
+
+    pre, approve, post, custom = get_templates(je, envpath, custom_template)
+
+    assert isinstance(pre, Template)
+    assert isinstance(post, Template)
+    assert isinstance(approve, Template)
+    assert isinstance(custom, Template)
+
 
 # this is as ugly as the tfvars file output tests
 def test_generate_config():
@@ -67,10 +81,27 @@ def test_generate_config():
     mock_envpath = "env_test"
     mock_outfile = "generated_config.yml"
     mock_workflow = "continuation-generated-workflow"
+    mock_template = None
 
-    generate_config(mock_pipeline, mock_pipepath, mock_outfile, mock_envpath, mock_multi, mock_workflow)
+    generate_config(mock_pipeline, mock_pipepath, mock_outfile, mock_envpath, mock_multi, mock_workflow, mock_template)
     assert os.path.isfile(os.path.join(mock_pipepath, mock_outfile))
     assert filecmp.cmp(os.path.join(mock_pipepath,
                        mock_outfile),
                        os.path.join("test",
                        mock_outfile))
+
+
+def test_generate_config_with_custom_template():
+    mock_pipeline = "release"
+    mock_pipepath = "env_test"
+    mock_envpath = "env_test"
+    mock_outfile = "template_generated_config.yml"
+    mock_workflow = "continuation-generated-workflow"
+    mock_template = "custom.yml"
+
+    generate_config(mock_pipeline, mock_pipepath, mock_outfile, mock_envpath, mock_multi, mock_workflow, mock_template)
+    assert os.path.isfile(os.path.join(mock_pipepath, mock_outfile))
+    assert filecmp.cmp(os.path.join(mock_pipepath,
+                                    mock_outfile),
+                       os.path.join("test",
+                                    mock_outfile))


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR implements the following **features**

* [ ] Bug
* [x] Feature: specify custom job template with `--template` flag
* [ ] Breaking changes

**Motivation**

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

This PR adds the ability to:
- Use a custom CircleCI job template to generate parallel jobs for all instances in the `multi.json` without approvals (Current definitions are highly specific to running TF pipelines with the twdps terraform orb and are not able to support more generic job definitions such as running a nightly validation test that is not dependent on terraform)
- Use generic jobs in the pre-existing config file without having to rely on orbs

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
